### PR TITLE
allow dev to specify headers when using POST

### DIFF
--- a/curl.go
+++ b/curl.go
@@ -94,7 +94,7 @@ func (p RequestParms) populateHeaders(req *http.Request) {
 }
 
 //provides a httpResponse for a GET,DELETE,POST or PUT. Can support json data, use "json" as a key on the parmeter
-func Curl(p RequestParms) (*http.Response, error) {
+func Curl(p RequestParms, headers ...map[string]string) (*http.Response, error) {
 	var client http.Client
 	var req *http.Request
 	var resp *http.Response
@@ -113,9 +113,15 @@ func Curl(p RequestParms) (*http.Response, error) {
 		if err != nil {
 			log.Println(err)
 		}
-		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-		req.Header.Add("Content-Length", strconv.Itoa(len(data.Encode())))
-		p.populateHeaders(req)
+		if len(headers) > 0 {
+			for k, v := range headers {
+				req.Header.Add(k, v)
+			}
+		} else {
+			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Add("Content-Length", strconv.Itoa(len(data.Encode())))
+			p.populateHeaders(req)
+		}
 		resp, err = client.Do(req)
 	}
 	if p.Method == HTTP_JSONPOST {

--- a/curl.go
+++ b/curl.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -99,7 +100,8 @@ func Curl(p RequestParms, headers ...map[string]string) (*http.Response, error) 
 	var req *http.Request
 	var resp *http.Response
 	var err error
-
+	log.Println(fmt.Sprintf("==== vtputils: p.Method : %s", p.Method))
+	log.Println(fmt.Sprintf("==== vtputils: headers len: %d", len(headers[0])))
 	if p.Method == HTTP_GET || p.Method == HTTP_DELETE {
 		url := buildGetUrl(p.Params, p.Endpoint)
 		req, _ = http.NewRequest(p.Method, url, nil)
@@ -107,14 +109,15 @@ func Curl(p RequestParms, headers ...map[string]string) (*http.Response, error) 
 		resp, err = client.Do(req)
 	}
 	if p.Method == HTTP_POST {
+		log.Println("== vtputils: IN POST")
 		url := p.Endpoint
 		data := formValues(p.Params)
 		req, err = http.NewRequest(p.Method, url, bytes.NewBufferString(data.Encode()))
 		if err != nil {
 			log.Println(err)
 		}
-		if len(headers) > 0 {
-			for k, v := range headers {
+		if len(headers[0]) > 0 {
+			for k, v := range headers[0] {
 				req.Header.Add(k, v)
 			}
 		} else {

--- a/curl.go
+++ b/curl.go
@@ -100,8 +100,6 @@ func Curl(p RequestParms, headers ...map[string]string) (*http.Response, error) 
 	var req *http.Request
 	var resp *http.Response
 	var err error
-	log.Println(fmt.Sprintf("==== vtputils: p.Method : %s", p.Method))
-	log.Println(fmt.Sprintf("==== vtputils: headers len: %d", len(headers[0])))
 	if p.Method == HTTP_GET || p.Method == HTTP_DELETE {
 		url := buildGetUrl(p.Params, p.Endpoint)
 		req, _ = http.NewRequest(p.Method, url, nil)
@@ -109,7 +107,6 @@ func Curl(p RequestParms, headers ...map[string]string) (*http.Response, error) 
 		resp, err = client.Do(req)
 	}
 	if p.Method == HTTP_POST {
-		log.Println("== vtputils: IN POST")
 		url := p.Endpoint
 		data := formValues(p.Params)
 		req, err = http.NewRequest(p.Method, url, bytes.NewBufferString(data.Encode()))


### PR DESCRIPTION
I found the auto added headers in Curl(..) with HttpPost did not match the requirements for my target web api site. With this pull request, the dev can pass a map[string]string of headers to Curl() as an optional second arg. When passed, only those headers are added, thus giving the dev fine grained control and total responsibility.
